### PR TITLE
Agrega clowns a las naves de Nanotrasen

### DIFF
--- a/_maps/configs/nanotrasen_delta.json
+++ b/_maps/configs/nanotrasen_delta.json
@@ -24,6 +24,7 @@
 			"outfit": "/datum/outfit/job/engineer/nt",
 			"slots": 1
 		},
+		"Clown": 1,
 		"Assistant": 3
 	},
 	"enabled": true

--- a/_maps/configs/nanotrasen_gecko.json
+++ b/_maps/configs/nanotrasen_gecko.json
@@ -31,6 +31,7 @@
 			"outfit": "/datum/outfit/job/miner/classic",
 			"slots": 2
 		},
+		"Clown": 1,
 		"Deckhand": {
 			"outfit": "/datum/outfit/job/assistant",
 			"slots": 4

--- a/_maps/configs/nanotrasen_mimir.json
+++ b/_maps/configs/nanotrasen_mimir.json
@@ -26,6 +26,7 @@
 			"outfit": "/datum/outfit/job/brig_phys",
 			"slots": 1
 		},
+		"Clown": 1,
 		"Patient": {
 			"outfit": "/datum/outfit/job/prisoner",
 			"slots": 2

--- a/_maps/configs/nanotrasen_osprey.json
+++ b/_maps/configs/nanotrasen_osprey.json
@@ -40,6 +40,7 @@
 		},
 		"Cook": 1,
 		"Janitor": 1,
+		"Clown": 1,
 		"Assistant": 3
 	},
 	"enabled": true

--- a/_maps/configs/nanotrasen_powerrangers.json
+++ b/_maps/configs/nanotrasen_powerrangers.json
@@ -46,6 +46,7 @@
 			"outfit": "/datum/outfit/job/scientist/lp",
 			"slots": 2
 		},
+		"Clown": 1,
 		"Miner": {
 			"outfit": "/datum/outfit/job/miner/lp",
 			"slots": 2

--- a/_maps/configs/nanotrasen_skipper.json
+++ b/_maps/configs/nanotrasen_skipper.json
@@ -39,6 +39,7 @@
 			"outfit": "/datum/outfit/job/security/nanotrasen",
 			"slots": 1
 		},
+		"Clown": 1,
 		"Assistant": 3
 	},
 	"enabled": true


### PR DESCRIPTION
Por lore NT contrata payasos para subir la moral de la crew,  aunq sea una estupida decision.  Hay muchos mains payasos en el server que se alegraran de poder jugar aqui tambien

![image](https://github.com/Helixis/Shiptest/assets/24284918/755060a5-589b-4f84-930b-5f4915a67ab5)

