### PR TITLE
Revert "Belts no longer fit in backpacks (#2164)"

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -10,7 +10,6 @@
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
-	w_class = WEIGHT_CLASS_BULKY
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
 	supports_variations = VOX_VARIATION
 	greyscale_icon_state = "belt"


### PR DESCRIPTION
This reverts commit fa1bf55b33a9ab8d1de2f400922ab1075576733e.

## PR HISPANICO

Revert al PR de cinturones

## Por que es bueno para el juego

![image](https://github.com/Helixis/Shiptest/assets/24284918/16c422c8-398b-434c-8f15-ebd966f630a3)

No veo beneficio de hacerle la vida mas complicada a los players para sus construcciones solo porque si. El toolbelt se utiliza para todo, no necesita esta clase de balance
