### PR TITLE
Andromeda arreglos

### DIFF
--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -2089,8 +2089,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "ut" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/cargo)
 "ux" = (
 /obj/structure/cable{
@@ -3540,19 +3539,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
-"GU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/closet/firecloset/full{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
 "GW" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/bus/preset_three{
@@ -3670,8 +3656,18 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
 "Ig" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/cargo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "Ij" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/processor/preset_three{
@@ -3769,6 +3765,7 @@
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
 	},
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
 "IT" = (
@@ -6493,7 +6490,7 @@ oN
 wz
 bH
 Vn
-GU
+Ig
 WR
 WR
 WR
@@ -6865,14 +6862,14 @@ EL
 Xx
 xB
 Tx
-Ig
+ut
 Us
 OG
 OG
 gn
 Xh
-Ig
-Ig
+ut
+ut
 zl
 zl
 zl
@@ -6898,7 +6895,7 @@ EL
 QA
 MD
 Yo
-Ig
+ut
 TU
 OL
 OL
@@ -6997,7 +6994,7 @@ EL
 EL
 EL
 EL
-Ig
+ut
 LO
 CB
 XO
@@ -7030,7 +7027,7 @@ EL
 EL
 Uc
 EL
-Ig
+ut
 UJ
 lg
 Uf
@@ -7063,12 +7060,12 @@ EL
 lX
 ML
 Gb
-Ig
+ut
 ZH
 lg
 MW
-Ig
-Ig
+ut
+ut
 xv
 ny
 zl
@@ -7096,11 +7093,11 @@ EL
 eh
 by
 Rf
-Ig
+ut
 ul
 JL
 hZ
-Ig
+ut
 zl
 zl
 zl
@@ -7129,11 +7126,11 @@ EL
 LB
 Da
 cl
-Ig
-Ig
-Ig
-Ig
-Ig
+ut
+ut
+ut
+ut
+ut
 zl
 zl
 zl

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -1408,10 +1408,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"mZ" = (
-/obj/machinery/computer/security,
-/turf/open/floor/wood,
-/area/ship/bridge)
 "nd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -5110,6 +5106,9 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
+"Un" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/cargo)
 "Ur" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -5255,9 +5254,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/atmospherics)
-"VH" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/cargo)
 "VV" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lantern{
@@ -6856,14 +6852,14 @@ EL
 Xx
 xB
 Tx
-VH
+Un
 Us
 OG
 OG
 gn
 Xh
-VH
-VH
+Un
+Un
 zl
 zl
 zl
@@ -6889,7 +6885,7 @@ EL
 QA
 MD
 Yo
-VH
+Un
 TU
 OL
 OL
@@ -6988,7 +6984,7 @@ EL
 EL
 EL
 EL
-VH
+Un
 LO
 CB
 XO
@@ -7021,7 +7017,7 @@ EL
 EL
 Uc
 EL
-VH
+Un
 UJ
 lg
 Uf
@@ -7054,12 +7050,12 @@ EL
 lX
 ML
 Gb
-VH
+Un
 ZH
 lg
 MW
-VH
-VH
+Un
+Un
 xv
 ny
 zl
@@ -7087,11 +7083,11 @@ EL
 eh
 by
 Rf
-VH
+Un
 ul
 JL
 hZ
-VH
+Un
 zl
 zl
 zl
@@ -7120,11 +7116,11 @@ EL
 LB
 Da
 cl
-VH
-VH
-VH
-VH
-VH
+Un
+Un
+Un
+Un
+Un
 zl
 zl
 zl
@@ -7285,7 +7281,7 @@ Xc
 EL
 zl
 yN
-mZ
+gQ
 Tb
 ky
 gQ

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -5255,6 +5255,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/atmospherics)
+"VH" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/cargo)
 "VV" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lantern{
@@ -5638,9 +5641,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/medical)
-"YF" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/cargo)
 "YI" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -5968,7 +5968,7 @@ zl
 zl
 zl
 gC
-ZO
+uf
 bH
 Fl
 bH
@@ -6011,7 +6011,7 @@ iO
 wv
 wv
 wv
-ZO
+uf
 "}
 (8,1,1) = {"
 zl
@@ -6856,14 +6856,14 @@ EL
 Xx
 xB
 Tx
-YF
+VH
 Us
 OG
 OG
 gn
 Xh
-YF
-YF
+VH
+VH
 zl
 zl
 zl
@@ -6889,7 +6889,7 @@ EL
 QA
 MD
 Yo
-YF
+VH
 TU
 OL
 OL
@@ -6988,7 +6988,7 @@ EL
 EL
 EL
 EL
-YF
+VH
 LO
 CB
 XO
@@ -7021,7 +7021,7 @@ EL
 EL
 Uc
 EL
-YF
+VH
 UJ
 lg
 Uf
@@ -7054,12 +7054,12 @@ EL
 lX
 ML
 Gb
-YF
+VH
 ZH
 lg
 MW
-YF
-YF
+VH
+VH
 xv
 ny
 zl
@@ -7087,11 +7087,11 @@ EL
 eh
 by
 Rf
-YF
+VH
 ul
 JL
 hZ
-YF
+VH
 zl
 zl
 zl
@@ -7120,11 +7120,11 @@ EL
 LB
 Da
 cl
-YF
-YF
-YF
-YF
-YF
+VH
+VH
+VH
+VH
+VH
 zl
 zl
 zl
@@ -7242,7 +7242,7 @@ zl
 zl
 zl
 zl
-ZO
+uf
 EL
 EL
 kQ

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -295,6 +295,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
 	},
+/obj/machinery/light/directional/west,
+/obj/item/storage/toolbox/ammo/shotgun,
+/obj/item/storage/toolbox/ammo/shotgun,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "cG" = (
@@ -958,12 +961,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"iN" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/ship/engineering/engine)
 "iO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/science/robotics)
@@ -2351,10 +2348,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
 "wA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/open/floor/engine,
 /area/ship/engineering/engine)
 "wB" = (
 /obj/machinery/telecomms/receiver/preset_right{
@@ -2469,6 +2466,12 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
+/area/ship/engineering/engine)
+"xH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/engineering/engine)
 "xI" = (
 /obj/structure/table/optable,
@@ -4199,6 +4202,9 @@
 	dir = 9
 	},
 /obj/structure/guncase,
+/obj/machinery/light/directional/west,
+/obj/item/gun/ballistic/shotgun/winchester/lethal,
+/obj/item/gun/ballistic/shotgun/winchester/lethal,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "Mx" = (
@@ -6135,7 +6141,7 @@ de
 QO
 xG
 hx
-wA
+xH
 uM
 kF
 ck
@@ -6330,7 +6336,7 @@ Uk
 ht
 de
 qJ
-iN
+wA
 Kp
 wW
 lN

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -3540,6 +3540,19 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
+"GU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "GW" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/bus/preset_three{
@@ -3656,6 +3669,9 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
+"Ig" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/cargo)
 "Ij" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/processor/preset_three{
@@ -5106,9 +5122,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
-"Un" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/cargo)
 "Ur" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -6480,7 +6493,7 @@ oN
 wz
 bH
 Vn
-GN
+GU
 WR
 WR
 WR
@@ -6852,14 +6865,14 @@ EL
 Xx
 xB
 Tx
-Un
+Ig
 Us
 OG
 OG
 gn
 Xh
-Un
-Un
+Ig
+Ig
 zl
 zl
 zl
@@ -6885,7 +6898,7 @@ EL
 QA
 MD
 Yo
-Un
+Ig
 TU
 OL
 OL
@@ -6984,7 +6997,7 @@ EL
 EL
 EL
 EL
-Un
+Ig
 LO
 CB
 XO
@@ -7017,7 +7030,7 @@ EL
 EL
 Uc
 EL
-Un
+Ig
 UJ
 lg
 Uf
@@ -7050,12 +7063,12 @@ EL
 lX
 ML
 Gb
-Un
+Ig
 ZH
 lg
 MW
-Un
-Un
+Ig
+Ig
 xv
 ny
 zl
@@ -7083,11 +7096,11 @@ EL
 eh
 by
 Rf
-Un
+Ig
 ul
 JL
 hZ
-Un
+Ig
 zl
 zl
 zl
@@ -7116,11 +7129,11 @@ EL
 LB
 Da
 cl
-Un
-Un
-Un
-Un
-Un
+Ig
+Ig
+Ig
+Ig
+Ig
 zl
 zl
 zl

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -378,7 +378,7 @@
 /area/ship/engineering)
 "dz" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/fuel,
 /area/ship/engineering/atmospherics)
 "dK" = (
 /obj/structure/table/wood,
@@ -663,7 +663,7 @@
 /area/ship/bridge)
 "gk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/fuel,
 /area/ship/engineering/atmospherics)
 "gn" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
@@ -800,11 +800,11 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "hx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/engineering/engine)
@@ -959,18 +959,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "iN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
 	},
-/obj/structure/closet/firecloset/full{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
+/turf/open/floor/engine,
+/area/ship/engineering/engine)
 "iO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/science/robotics)
@@ -1699,6 +1692,16 @@
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/wood,
 /area/ship/bridge)
+"pV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "pY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1773,7 +1776,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -2232,7 +2235,7 @@
 	id_tag = "incinerator_sensor";
 	name = "incineration mixing gas sensor"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/ship/engineering/engine)
 "vP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -2347,6 +2350,12 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
+"wA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/engineering/engine)
 "wB" = (
 /obj/machinery/telecomms/receiver/preset_right{
 	freq_listening = list(1347,1359,1213,1353);
@@ -3163,9 +3172,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Dw" = (
@@ -3478,6 +3485,19 @@
 /obj/item/defibrillator,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"Gz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "GN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -3527,13 +3547,11 @@
 /turf/open/floor/plating/airless,
 /area/ship/external/dark)
 "HA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "HD" = (
@@ -3667,7 +3685,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "IK" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/mono/dark,
@@ -3876,7 +3894,7 @@
 /area/ship/engineering/atmospherics)
 "Ka" = (
 /obj/effect/turf_decal/atmos/plasma,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/fuel,
 /area/ship/engineering/atmospherics)
 "Kf" = (
 /obj/machinery/jukebox,
@@ -4033,18 +4051,18 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/ship/engineering/engine)
 "Lh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Lo" = (
@@ -4109,10 +4127,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/science/robotics)
 "LT" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "LU" = (
@@ -4534,9 +4552,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "PU" = (
@@ -4770,9 +4785,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Sa" = (
@@ -5068,14 +5080,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
-"Un" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "Ur" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -5334,7 +5338,7 @@
 /area/ship/bridge)
 "WI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/fuel,
 /area/ship/engineering/atmospherics)
 "WK" = (
 /obj/structure/toilet{
@@ -5376,13 +5380,16 @@
 /area/ship/crew/toilet)
 "WT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "WW" = (
@@ -5506,7 +5513,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/ship/engineering/engine)
 "XX" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
@@ -6128,7 +6135,7 @@ de
 QO
 xG
 hx
-de
+wA
 uM
 kF
 ck
@@ -6194,7 +6201,7 @@ gc
 Tc
 tS
 HA
-Un
+pV
 nl
 Cx
 WG
@@ -6323,7 +6330,7 @@ Uk
 ht
 de
 qJ
-th
+iN
 Kp
 wW
 lN
@@ -6449,7 +6456,7 @@ oN
 wz
 bH
 Vn
-iN
+Gz
 WR
 WR
 WR

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -296,8 +296,6 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/west,
-/obj/item/storage/toolbox/ammo/shotgun,
-/obj/item/storage/toolbox/ammo/shotgun,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "cG" = (
@@ -755,11 +753,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
-"gM" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/engineering{
-	name = "Propulsor 1"
-	})
 "gN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1221,9 +1214,7 @@
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "ln" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 4;
@@ -2192,9 +2183,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "vg" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 4;
@@ -2320,9 +2309,7 @@
 /obj/machinery/door/poddoor{
 	id = "andromeda_mech_blast_2"
 	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 8;
@@ -2603,9 +2590,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
 "yE" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 4;
@@ -3048,9 +3033,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Cl" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 8;
@@ -4109,9 +4092,7 @@
 /obj/machinery/door/poddoor{
 	id = "andromeda_mech_blast_1"
 	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 8;
@@ -4207,9 +4188,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Mm" = (
@@ -4218,8 +4197,6 @@
 	},
 /obj/structure/guncase,
 /obj/machinery/light/directional/west,
-/obj/item/gun/ballistic/shotgun/winchester/lethal,
-/obj/item/gun/ballistic/shotgun/winchester/lethal,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "Mx" = (
@@ -4345,7 +4322,7 @@
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
 	input_tag = "incinerator_in";
-	sensors = list("incinerator_sensor" = "Incinerator Chamber");
+	sensors = list("incinerator_sensor"="Incinerator Chamber");
 	output_tag = "incinerator_out";
 	name = "Incinerator Chamber Control"
 	},
@@ -5733,9 +5710,7 @@
 /area/ship/security/armory)
 "Zy" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/structure/cable,
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -6412,7 +6387,7 @@ XN
 bH
 EY
 Tv
-gM
+bH
 Ik
 Ik
 Ov
@@ -6445,7 +6420,7 @@ pr
 bH
 Iw
 BU
-gM
+bH
 HG
 HG
 Ov

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -216,7 +216,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/bridge)
 "co" = (
 /obj/machinery/light/directional/west,
@@ -481,7 +481,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
 	dir = 4
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/engineering)
 "eu" = (
 /obj/structure/table/wood,
@@ -1075,9 +1075,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
-"jP" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/security/armory)
 "jY" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
@@ -3547,9 +3544,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
-"GU" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/engineering/atmospherics)
 "GW" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/bus/preset_three{
@@ -3666,9 +3660,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
-"Ig" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/engineering)
 "Ij" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/processor/preset_three{
@@ -4060,9 +4051,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"KO" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/bridge)
 "KQ" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/mono/dark,
@@ -4151,7 +4139,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/bridge)
 "LG" = (
 /obj/machinery/autolathe/hacked,
@@ -4631,7 +4619,7 @@
 /area/ship/engineering/communications)
 "Qq" = (
 /obj/structure/sign/poster/contraband/bulldog,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/bridge)
 "QA" = (
 /obj/machinery/vending/cigarette,
@@ -4701,7 +4689,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/security/armory)
 "Rf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -5122,9 +5110,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
-"Un" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/medical)
 "Ur" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -5270,9 +5255,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/atmospherics)
-"VH" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/science/robotics)
 "VV" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lantern{
@@ -5657,8 +5639,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/medical)
 "YF" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/engineering/engine)
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/cargo)
 "YI" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -5834,7 +5816,7 @@ Fb
 at
 "}
 (2,1,1) = {"
-Ig
+bH
 bH
 BR
 BR
@@ -5864,10 +5846,10 @@ Wo
 Wo
 Wo
 bH
-Ig
+bH
 "}
 (3,1,1) = {"
-Ig
+bH
 Ci
 dW
 dW
@@ -5897,10 +5879,10 @@ dW
 dW
 dW
 Ci
-Ig
+bH
 "}
 (4,1,1) = {"
-Ig
+bH
 Ci
 ZP
 ux
@@ -5930,10 +5912,10 @@ BW
 XU
 aT
 Ci
-Ig
+bH
 "}
 (5,1,1) = {"
-Ig
+bH
 bK
 kI
 KA
@@ -5963,10 +5945,10 @@ jz
 Ec
 CC
 Zy
-Ig
+bH
 "}
 (6,1,1) = {"
-Ig
+bH
 mC
 Xb
 iL
@@ -5996,11 +5978,11 @@ bH
 bH
 Xb
 mC
-Ig
+bH
 "}
 (7,1,1) = {"
-ZO
-GU
+uf
+Sr
 Sr
 Sr
 Sr
@@ -6009,7 +5991,7 @@ Ah
 sX
 sY
 Sr
-Ig
+bH
 dX
 Kg
 zl
@@ -6019,7 +6001,7 @@ zl
 zl
 Kg
 gC
-Ig
+bH
 wv
 wv
 wv
@@ -6028,12 +6010,12 @@ FP
 iO
 wv
 wv
-VH
+wv
 ZO
 "}
 (8,1,1) = {"
 zl
-GU
+Sr
 mM
 XX
 vB
@@ -6042,17 +6024,17 @@ Jr
 Ue
 pr
 Sr
-Ig
+bH
 ep
-Ig
-YF
+bH
+de
 de
 pG
 de
-YF
-Ig
-Ig
-Ig
+de
+bH
+bH
+bH
 wv
 hj
 iO
@@ -6061,12 +6043,12 @@ FP
 iO
 OJ
 iO
-VH
+wv
 zl
 "}
 (9,1,1) = {"
 zl
-GU
+Sr
 gS
 Ot
 VE
@@ -6078,11 +6060,11 @@ Sr
 UO
 eP
 Sa
-YF
+de
 XV
 vK
 Lg
-YF
+de
 xQ
 kF
 st
@@ -6099,7 +6081,7 @@ zl
 "}
 (10,1,1) = {"
 zl
-GU
+Sr
 OM
 OM
 Zf
@@ -6111,11 +6093,11 @@ Sr
 Vb
 IK
 aH
-YF
+de
 Sn
 JK
 xp
-YF
+de
 zI
 kF
 Rr
@@ -6132,7 +6114,7 @@ zl
 "}
 (11,1,1) = {"
 zl
-GU
+Sr
 rM
 FC
 vB
@@ -6144,11 +6126,11 @@ Sr
 hS
 eP
 aH
-YF
+de
 hQ
 pg
 cv
-YF
+de
 yX
 kF
 KQ
@@ -6165,7 +6147,7 @@ zl
 "}
 (12,1,1) = {"
 zl
-GU
+Sr
 AB
 KL
 Jo
@@ -6177,11 +6159,11 @@ Sr
 wY
 eP
 Sa
-YF
+de
 QO
 xG
 hx
-YF
+de
 uM
 kF
 ck
@@ -6193,12 +6175,12 @@ UT
 AX
 iu
 Nz
-VH
+wv
 zl
 "}
 (13,1,1) = {"
 Kg
-GU
+Sr
 OM
 OM
 rc
@@ -6226,12 +6208,12 @@ FP
 iO
 iu
 iO
-VH
+wv
 Hl
 "}
 (14,1,1) = {"
 zl
-GU
+Sr
 Ka
 WI
 vB
@@ -6264,7 +6246,7 @@ zl
 "}
 (15,1,1) = {"
 zl
-GU
+Sr
 dz
 gk
 Yc
@@ -6297,7 +6279,7 @@ zl
 "}
 (16,1,1) = {"
 zl
-GU
+Sr
 OM
 OM
 Zf
@@ -6330,7 +6312,7 @@ zl
 "}
 (17,1,1) = {"
 zl
-GU
+Sr
 AS
 ZQ
 VE
@@ -6358,12 +6340,12 @@ MT
 vy
 iO
 bu
-VH
+wv
 zl
 "}
 (18,1,1) = {"
 zl
-GU
+Sr
 aI
 lp
 VE
@@ -6391,12 +6373,12 @@ it
 it
 it
 it
-Ls
+it
 zl
 "}
 (19,1,1) = {"
 zl
-GU
+Sr
 Sr
 Sr
 jD
@@ -6424,12 +6406,12 @@ Aa
 GW
 wB
 ia
-Ls
+it
 zl
 "}
 (20,1,1) = {"
 zl
-GU
+Sr
 Fe
 Fe
 jo
@@ -6457,12 +6439,12 @@ rJ
 ft
 gN
 Qm
-Ls
+it
 zl
 "}
 (21,1,1) = {"
 zl
-GU
+Sr
 yz
 Fe
 jo
@@ -6490,12 +6472,12 @@ wh
 Ij
 Ju
 bG
-Ls
+it
 zl
 "}
 (22,1,1) = {"
 zl
-GU
+Sr
 Fe
 Fe
 oN
@@ -6523,15 +6505,15 @@ it
 it
 it
 Ls
-ZO
+uf
 zl
 "}
 (23,1,1) = {"
 zl
-ZO
-GU
-GU
-GU
+uf
+Sr
+Sr
+Sr
 Sr
 bH
 iZ
@@ -6719,7 +6701,7 @@ uH
 YJ
 NR
 dZ
-Un
+Vk
 zl
 zl
 zl
@@ -6752,7 +6734,7 @@ Pn
 oT
 oT
 yn
-Un
+Vk
 zl
 zl
 zl
@@ -6785,7 +6767,7 @@ Op
 oT
 oT
 wQ
-Un
+Vk
 zl
 zl
 zl
@@ -6818,7 +6800,7 @@ rl
 sI
 we
 kY
-Un
+Vk
 zl
 zl
 zl
@@ -6828,16 +6810,16 @@ zl
 zl
 zl
 zl
-ZO
+uf
 po
 po
-jP
-jP
-jP
-jP
+po
+po
+po
+po
 pv
-KO
-KO
+EL
+EL
 Nf
 MD
 Id
@@ -6848,9 +6830,9 @@ Vk
 Vk
 Vk
 Vk
-Un
-Un
-Un
+Vk
+Vk
+Vk
 uf
 zl
 zl
@@ -6862,26 +6844,26 @@ zl
 zl
 zl
 zl
-jP
-jP
+po
+po
 Mm
 Za
 cE
-jP
+po
 Cn
 DB
-KO
+EL
 Xx
 xB
 Tx
-xv
+YF
 Us
 OG
 OG
 gn
 Xh
-xv
-xv
+YF
+YF
 zl
 zl
 zl
@@ -6896,18 +6878,18 @@ zl
 zl
 zl
 zl
-jP
+po
 hd
 lP
 qn
-jP
+po
 BE
 bz
-KO
+EL
 QA
 MD
 Yo
-xv
+YF
 TU
 OL
 OL
@@ -6929,14 +6911,14 @@ zl
 zl
 zl
 zl
-jP
+po
 Zx
 iG
 Gm
-jP
+po
 CP
 Uu
-KO
+EL
 RU
 MD
 Yo
@@ -6962,11 +6944,11 @@ zl
 zl
 zl
 zl
-jP
-jP
+po
+po
 AE
 Rc
-jP
+po
 RM
 wq
 Qq
@@ -6995,18 +6977,18 @@ zl
 zl
 zl
 zl
-jP
+po
 Ch
 yt
 KU
 zx
 su
 IF
-KO
-KO
-KO
-KO
-xv
+EL
+EL
+EL
+EL
+YF
 LO
 CB
 XO
@@ -7028,18 +7010,18 @@ zl
 zl
 zl
 zl
-jP
+po
 TL
 QX
 Ru
-jP
+po
 NP
 DB
-KO
-KO
+EL
+EL
 Uc
-KO
-xv
+EL
+YF
 UJ
 lg
 Uf
@@ -7061,23 +7043,23 @@ zl
 zl
 zl
 zl
-ZO
-jP
-jP
-jP
-jP
+uf
+po
+po
+po
+po
 Ep
 Cq
-KO
+EL
 lX
 ML
 Gb
-xv
+YF
 ZH
 lg
 MW
-xv
-xv
+YF
+YF
 xv
 ny
 zl
@@ -7095,21 +7077,21 @@ zl
 zl
 zl
 zl
-KO
+EL
 Ur
 jO
 En
 SF
 Yt
-KO
+EL
 eh
 by
 Rf
-xv
+YF
 ul
 JL
 hZ
-xv
+YF
 zl
 zl
 zl
@@ -7128,21 +7110,21 @@ zl
 zl
 zl
 zl
-KO
+EL
 mB
 MZ
 OS
 SK
 aF
-KO
+EL
 LB
 Da
 cl
-xv
-xv
-xv
-xv
-xv
+YF
+YF
+YF
+YF
+YF
 zl
 zl
 zl
@@ -7161,7 +7143,7 @@ zl
 zl
 zl
 zl
-KO
+EL
 pZ
 SL
 Io
@@ -7175,7 +7157,7 @@ Yg
 oi
 if
 cA
-KO
+EL
 zl
 zl
 zl
@@ -7194,21 +7176,21 @@ zl
 zl
 zl
 zl
-KO
+EL
 Yb
 Wu
 cy
 qe
 zL
 eX
-KO
-KO
-KO
+EL
+EL
+EL
 pM
 Kx
 pK
 ru
-KO
+EL
 zl
 zl
 zl
@@ -7227,16 +7209,16 @@ zl
 zl
 zl
 zl
-KO
+EL
 uJ
 UU
 oS
 IT
 TN
 Es
-KO
+EL
 zl
-KO
+EL
 mr
 yb
 Fd
@@ -7261,13 +7243,13 @@ zl
 zl
 zl
 ZO
-KO
-KO
+EL
+EL
 kQ
 vF
 ME
 Am
-KO
+EL
 zl
 EL
 Wk
@@ -7300,7 +7282,7 @@ EQ
 UA
 Ty
 Xc
-KO
+EL
 zl
 yN
 mZ

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -958,6 +958,19 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"iN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "iO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/science/robotics)
@@ -1686,12 +1699,6 @@
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/wood,
 /area/ship/bridge)
-"pV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ship/engineering/engine)
 "pY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -2000,6 +2007,12 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"th" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ship/engineering/engine)
 "tS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -3987,19 +4000,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
-"KO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/closet/firecloset/full{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
 "KQ" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/mono/dark,
@@ -5068,6 +5068,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
+"Un" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "Ur" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -5213,14 +5221,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/atmospherics)
-"VH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "VV" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lantern{
@@ -5503,9 +5503,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "XV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
-	dir = 4;
-	id = "incinerator_out"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -6195,7 +6194,7 @@ gc
 Tc
 tS
 HA
-VH
+Un
 nl
 Cx
 WG
@@ -6258,7 +6257,7 @@ Ns
 Vw
 de
 lh
-pV
+th
 gf
 wW
 lN
@@ -6324,7 +6323,7 @@ Uk
 ht
 de
 qJ
-pV
+th
 Kp
 wW
 lN
@@ -6450,7 +6449,7 @@ oN
 wz
 bH
 Vn
-KO
+iN
 WR
 WR
 WR

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -632,7 +632,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "gf" = (
@@ -736,8 +738,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "gL" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "gM" = (

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -488,7 +488,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "andromeda_windows";
+	name = "Window Shield";
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "eu" = (
 /obj/structure/table/wood,
@@ -960,6 +966,15 @@
 	can_be_unanchored = 1
 	},
 /turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"iN" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "andromeda_windows";
+	name = "Window Shield";
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "iO" = (
 /turf/open/floor/plasteel/dark,
@@ -1789,6 +1804,12 @@
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
+"rc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/engineering/engine)
 "rj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -2347,12 +2368,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
-"wA" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/ship/engineering/engine)
 "wB" = (
 /obj/machinery/telecomms/receiver/preset_right{
 	freq_listening = list(1347,1359,1213,1353);
@@ -2466,12 +2481,6 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ship/engineering/engine)
-"xH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ship/engineering/engine)
 "xI" = (
 /obj/structure/table/optable,
@@ -3770,6 +3779,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
+"Jo" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/ship/engineering/engine)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -6011,7 +6026,7 @@ pG
 de
 de
 bH
-bH
+iN
 bH
 wv
 hj
@@ -6141,7 +6156,7 @@ de
 QO
 xG
 hx
-xH
+rc
 uM
 kF
 ck
@@ -6336,7 +6351,7 @@ Uk
 ht
 de
 qJ
-wA
+Jo
 Kp
 wW
 lN

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -448,6 +448,10 @@
 	name = "atmos waste outlet injector"
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4;
+	name = "atmos waste outlet injector"
+	},
 /turf/open/floor/plating,
 /area/ship/external/dark)
 "dZ" = (
@@ -765,6 +769,9 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "hd" = (
@@ -951,22 +958,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"iN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
 "iO" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/science/robotics)
@@ -1295,6 +1286,9 @@
 /area/ship/engineering/engine)
 "lN" = (
 /obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "lP" = (
@@ -1412,7 +1406,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/mixer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -1420,6 +1413,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "nf" = (
@@ -1772,7 +1766,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
@@ -1788,13 +1782,6 @@
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
-"rc" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/engineering/atmospherics)
 "rj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -2013,12 +2000,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"th" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/ship/engineering/engine)
 "tS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -2353,22 +2334,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
-"wA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/catwalk/over/plated_catwalk/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/atmospherics)
 "wB" = (
 /obj/machinery/telecomms/receiver/preset_right{
 	freq_listening = list(1347,1359,1213,1353);
@@ -2483,18 +2448,6 @@
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
-"xH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Oxygen to Mix"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/atmospherics)
 "xI" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
@@ -3512,12 +3465,6 @@
 /obj/item/defibrillator,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Gz" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ship/engineering/engine)
 "GN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -3655,19 +3602,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
-"Ig" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/closet/firecloset/full{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
 "Ij" = (
 /obj/structure/window/plasma/reinforced/spawner/north,
 /obj/machinery/telecomms/processor/preset_three{
@@ -3802,13 +3736,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/hallway/central)
-"Jo" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ship/engineering/atmospherics)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -4060,6 +3987,19 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
+"KO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "KQ" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/mono/dark,
@@ -4575,6 +4515,9 @@
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)
 "PP" = (
@@ -4591,6 +4534,9 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "PU" = (
@@ -4824,6 +4770,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Sa" = (
@@ -5264,6 +5213,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/atmospherics)
+"VH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "VV" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lantern{
@@ -5422,6 +5379,9 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
@@ -6156,7 +6116,7 @@ zl
 Sr
 AB
 KL
-Jo
+VE
 WW
 eN
 JS
@@ -6189,9 +6149,9 @@ Kg
 Sr
 OM
 OM
-rc
-xH
-wA
+Zf
+Mx
+Jr
 ya
 nF
 Sr
@@ -6224,7 +6184,7 @@ Ka
 WI
 vB
 hC
-iN
+Jr
 ya
 bT
 Sr
@@ -6235,7 +6195,7 @@ gc
 Tc
 tS
 HA
-tS
+VH
 nl
 Cx
 WG
@@ -6300,7 +6260,7 @@ de
 lh
 pV
 gf
-Gz
+wW
 lN
 de
 wZ
@@ -6364,7 +6324,7 @@ Uk
 ht
 de
 qJ
-th
+pV
 Kp
 wW
 lN
@@ -6490,7 +6450,7 @@ oN
 wz
 bH
 Vn
-Ig
+KO
 WR
 WR
 WR

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -5551,7 +5551,8 @@
 /area/ship/engineering)
 "XV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
-	dir = 4
+	dir = 4;
+	id = "incinerator_out"
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)

--- a/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/syndicate_andromeda.dmm
@@ -1698,8 +1698,8 @@
 /turf/open/floor/wood,
 /area/ship/bridge)
 "pV" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/ship/engineering/engine)


### PR DESCRIPTION
## PR HISPANICO

Cambios y arreglos:

-Desconecta el TEG del sistema de filtros.

-Ahora el compartimento de plasma usa el fuel mix floor, en lugar del plasma floor.

-Se ha movido un adaptador que mezclaba el sistema de ventilación con el inyector del TEG.

-Se han añadido 2 ventanas en la parte trasera de la nave que permite ver mejor la salida de gases.

-Se han remplazado los muros, por versiones nondiagonal, evitando que haya bugs visuales.

-El orm se ha movido un tile adelante y se ha añadido un muro, esto porque en caso de descompresión, afectaba tambien al central hall.

-Ahora en el incinerador hay un air scrubber, en lugar del output.

## Por que es bueno para el juego

Arregla fallos que no se habían apreciado anteriormente y mejoran la nave en general.