### PR TITLE
Kansatsu de INTEQ

### DIFF
--- a/_maps/HISPANIAconfigs/inteq_kansatsu_halterio.json
+++ b/_maps/HISPANIAconfigs/inteq_kansatsu_halterio.json
@@ -1,0 +1,34 @@
+{
+  "map_name": "Kansatsu-Class Halterio",
+  "prefix": "IRMV",
+  "namelists": [
+    "MYTHOLOGICAL",
+    "BEASTS",
+    "NATURAL_AGGRESSIVE",
+    "INTEQ"
+  ],
+  "map_short_name": "Kansatsu-Class Halterio",
+  "description": "Originalmente un modelo mensajero Type-S de SolGov, remodelado por Cybersun en la Kansatsu para misiones de reconocimiento o espionaje.\n\nEsta nave en particular fue carpturada y re-armada por INTEQ para acomodar la nave a las peculiares necesidades de sus nuevos dueños, debido a su reducido tamaño, se suele preferir para misiones cortas de ataque y retirada",
+  "tags": [
+    "Combat"
+  ],
+  "map_path": "_maps/shuttles/shiptest/inteq_kansatsu_halterio.dmm",
+  "map_id": "inteq_kansatsu_halterio",
+  "limit": 1,
+  "job_slots": {
+    "Vanguard": {
+      "outfit": "/datum/outfit/job/captain/inteq/naked",
+      "officer": true,
+      "slots": 2
+    },
+    "Enforcer": {
+      "outfit": "/datum/outfit/job/security/inteq",
+      "slots": 3
+    },
+    "Recruit": {
+      "outfit": "/datum/outfit/job/assistant/inteq",
+      "slots": 3
+    }
+  },
+  "enabled": true
+}

--- a/_maps/shuttles/shiptestHISPANIA/inteq_kansatsu_halterio.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/inteq_kansatsu_halterio.dmm
@@ -1,0 +1,2422 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"ah" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"aE" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = 24
+	},
+/obj/structure/closet,
+/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
+/obj/item/gun/ballistic/automatic/pistol/commander/inteq,
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler,
+/obj/item/gun/ballistic/automatic/pistol/APS,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"aI" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/medical/surgery)
+"aL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/tank/jetpack/oxygen/harness,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/item/clothing/suit/space/inteq,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"aQ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"aT" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 10
+	},
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"aU" = (
+/obj/structure/sign/poster/contraband/inteq,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/armory)
+"aZ" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/effect/turf_decal/box,
+/obj/machinery/firealarm/directional/west,
+/obj/item/reagent_containers/food/snacks/canned/peaches,
+/obj/item/reagent_containers/food/snacks/canned/peaches,
+/obj/item/reagent_containers/food/snacks/canned/peaches,
+/obj/item/reagent_containers/food/snacks/canned/peaches,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"bn" = (
+/obj/structure/sign/poster/retro/we_watch,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
+"bI" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"bO" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
+"cu" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/docking_port/mobile{
+	callTime = 250;
+	dir = 2;
+	launch_status = 0;
+	name = "Scout Courier";
+	port_direction = 8;
+	preferred_direction = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"cw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"cy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Crew Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"cL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"cZ" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/cargo)
+"dd" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/molotov,
+/obj/item/reagent_containers/food/drinks/bottle/molotov,
+/obj/item/reagent_containers/food/drinks/bottle/molotov,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"dj" = (
+/obj/item/toy/cards/deck,
+/obj/machinery/light/small/broken/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"dq" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate{
+	name = "communications gear"
+	},
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/paper{
+	info = "Congratulations on your purchase of Cybersun G-1010 Long Range Communication Tables (Chat client installed seperately)"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"dA" = (
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Bridge"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "intelfucky"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"el" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"eu" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"ev" = (
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs,
+/area/ship/cargo)
+"eX" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "intelwindow"
+	},
+/turf/open/floor/plating,
+/area/ship/medical/surgery)
+"fk" = (
+/obj/machinery/computer/cargo/express{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	id = "intelfucky";
+	name = "Privacy Lock";
+	pixel_x = -7;
+	pixel_y = -23
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
+"gj" = (
+/obj/item/toy/plush/spider,
+/obj/structure/closet/emcloset/anchored,
+/obj/item/clothing/head/papersack,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/engineering)
+"gP" = (
+/obj/machinery/door/poddoor{
+	id = "scbay"
+	},
+/obj/structure/cable,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "scholo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"he" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"hr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"hM" = (
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"hT" = (
+/obj/structure/curtain/cloth,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
+"ii" = (
+/obj/machinery/power/apc/auto_name/directional/east{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_y = -30
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"im" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"iL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"iN" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"iY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/spline/fancy/transparent/grey,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"jj" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/cargo)
+"jW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"km" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/table,
+/obj/item/chair/plastic,
+/obj/item/chair/plastic{
+	pixel_y = 8
+	},
+/obj/item/chair/plastic{
+	pixel_y = 16
+	},
+/obj/item/stack/sheet/mineral/wood{
+	amount = 3
+	},
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"lP" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8;
+	piping_layer = 2
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"lV" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/tank/jetpack/oxygen/harness,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/item/clothing/suit/space/inteq,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"nd" = (
+/obj/structure/sign/poster/contraband/inteq,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/medical/surgery)
+"ni" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"nu" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"nF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"nO" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/red,
+/obj/machinery/camera,
+/turf/open/floor/plating,
+/area/ship/external)
+"nP" = (
+/obj/structure/sign/poster/contraband/borg_fancy_2,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/armory)
+"nU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/ship/security/armory)
+"ob" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/combat,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"ot" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/medical/surgery)
+"oB" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"oN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock{
+	name = "Cryopod Room"
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"qa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"qe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "thefunny"
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Office"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"qf" = (
+/obj/machinery/door/poddoor{
+	id = "scbay"
+	},
+/obj/structure/cable,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "scholo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"ql" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"qv" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/clothing/mask/fakemoustache,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "scengine"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"qA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/dorm)
+"qF" = (
+/obj/machinery/power/apc/auto_name/directional/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/item/kirbyplants/fullysynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"qS" = (
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"qY" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/button/door{
+	dir = 4;
+	id = "thefunny";
+	pixel_x = -23;
+	pixel_y = 9
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = "intelwindow";
+	name = "Window Shutters";
+	pixel_x = -23;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/table/greyscale,
+/obj/item/healthanalyzer/advanced,
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"re" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 3;
+	height = 15;
+	width = 7
+	},
+/turf/template_noop,
+/area/template_noop)
+"rh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"rj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"ru" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"rF" = (
+/obj/machinery/button/door{
+	dir = 8;
+	id = "scengine";
+	name = "Engine Blast Shutters";
+	pixel_x = -8
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"rR" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"so" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 5
+	},
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"tk" = (
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner{
+	dir = 8
+	},
+/obj/item/kirbyplants/fullysynthetic,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"tv" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"ty" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/rack,
+/obj/effect/turf_decal/box,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance/five,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/item/stack/marker_beacon/thirty,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"tD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_y = 30
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"tV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/robustmore_drinkfoods{
+	pixel_y = -32
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"uq" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"vk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"vL" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"vN" = (
+/obj/structure/table/reinforced,
+/obj/item/binoculars,
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch.";
+	id = "scbay";
+	name = "Cargo Bay Doors";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/machinery/button/door{
+	id = "scbridge";
+	name = "Bridge Blast Shutters";
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "scholo";
+	name = "Holofield Controls";
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"wo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner,
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"xf" = (
+/obj/machinery/power/apc/auto_name/directional/south{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	id = "scholo";
+	name = "Holofield Controls";
+	pixel_x = -6;
+	pixel_y = -33
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch.";
+	dir = 1;
+	id = "scbay";
+	name = "Cargo Bay Doors";
+	pixel_x = 3;
+	pixel_y = -35
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"yl" = (
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"yn" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/heat,
+/obj/item/clothing/glasses/heat,
+/obj/item/clothing/glasses/cold,
+/obj/item/clothing/glasses/cold,
+/obj/effect/turf_decal/box,
+/obj/item/clothing/under/color/black,
+/obj/item/clothing/under/color/black,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/head/beanie/black,
+/obj/item/clothing/head/beanie/black,
+/obj/machinery/light/directional/west,
+/obj/item/clothing/mask/fakemoustache/italian,
+/obj/item/clothing/mask/fakemoustache/italian,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"yw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"yF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"yG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"yH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"zH" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"zO" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"zY" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"AM" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"Bt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Cr" = (
+/obj/machinery/door/poddoor{
+	id = "scbay"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"CP" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/hatch/red,
+/obj/machinery/power/apc/auto_name/directional/east{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm)
+"CR" = (
+/obj/machinery/porta_turret/ship,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
+"CU" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "scengine"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Dm" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/armory)
+"DB" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"DL" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"DU" = (
+/obj/structure/chair/office{
+	dir = 4;
+	name = "Intel Officer's Chair"
+	},
+/obj/item/radio/intercom/wideband/directional/south{
+	reach = 2
+	},
+/obj/effect/turf_decal/trimline/opaque/bar,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"Em" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner,
+/obj/structure/closet/wall{
+	pixel_y = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/head/helmet/inteq,
+/obj/item/clothing/head/helmet/inteq,
+/obj/item/clothing/head/helmet/inteq,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/head/helmet/inteq,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/under/syndicate/inteq,
+/obj/item/clothing/under/syndicate/inteq,
+/obj/item/clothing/under/syndicate/inteq,
+/obj/item/clothing/under/syndicate/inteq,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"FH" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "scbridge"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"FJ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"FL" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 8
+	},
+/obj/structure/closet/wall{
+	pixel_y = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/c9mm/surplus,
+/obj/item/ammo_box/c9mm/surplus,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/obj/item/ammo_box/magazine/pistolm9mm,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"FR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/east{
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"FT" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"GG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
+"GV" = (
+/obj/machinery/porta_turret/ship/weak,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
+"Hd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/item/bedsheet/blue,
+/obj/structure/bed/pod,
+/obj/structure/curtain,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew/dorm)
+"Hz" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate{
+	name = "recreation package"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/item/circuitboard/machine/microwave,
+/obj/item/vending_refill/boozeomat,
+/obj/item/circuitboard/machine/vendor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"Ig" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"IP" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 4
+	},
+/obj/machinery/stasis,
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"Jp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/closet/wall{
+	pixel_y = 28
+	},
+/obj/machinery/computer/cryopod/directional/west,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/turf/open/floor/plasteel/white,
+/area/ship/crew/dorm)
+"JI" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"Ky" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/machinery/door/window/brigdoor{
+	name = "Gear Stowage";
+	req_access_txt = "1"
+	},
+/obj/item/storage/box/syndie_kit/chameleon,
+/obj/item/storage/box/syndie_kit/chameleon,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/central)
+"Ld" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"Lr" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/crew/dorm)
+"LL" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/north,
+/obj/item/kirbyplants/fullysynthetic,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"Mb" = (
+/obj/structure/chair/office{
+	dir = 4;
+	name = "Captain's Chair"
+	},
+/obj/machinery/turretid{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/opaque/bar,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"Nu" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"NU" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "scengine"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"NW" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = 24
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"Oi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"Ox" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"OD" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"OM" = (
+/obj/structure/table/reinforced,
+/obj/item/binoculars{
+	pixel_x = 4
+	},
+/obj/item/clipboard,
+/obj/item/pen,
+/obj/item/camera{
+	pixel_x = -1;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/obj/item/gps,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"OP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"OR" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/obj/item/grenade/c4,
+/turf/open/floor/plasteel/dark,
+/area/ship/security/armory)
+"OW" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"OY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/structure/table/greyscale,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"Pc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/ship/security/armory)
+"Pk" = (
+/obj/machinery/mineral/ore_redemption{
+	dir = 8;
+	input_dir = 8;
+	output_dir = null
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/directional/east{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"Qa" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/bridge)
+"Ql" = (
+/obj/effect/turf_decal/atmos/air,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Qx" = (
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs,
+/area/ship/cargo)
+"Qy" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"QJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"QM" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/table/greyscale,
+/obj/machinery/cell_charger,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"QN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/crew/dorm)
+"QO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = -4
+	},
+/obj/item/pen/fountain,
+/obj/item/folder/syndicate{
+	icon_state = "folder_sred";
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/bridge)
+"Ri" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
+"Rj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"Rr" = (
+/obj/effect/turf_decal/trimline/opaque/bar/filled/corner,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/ship/hallway/central)
+"Rv" = (
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/box,
+/obj/structure/sign/poster/contraband/energy_swords{
+	pixel_x = 31
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Rz" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "scbridge"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Sx" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"SH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Ue" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"Ul" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_x = -27
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"UZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/cargo)
+"Va" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Xa" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Xc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "intelfucky"
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ship/bridge)
+"Xw" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"XB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
+/area/ship/security/armory)
+"XJ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"YG" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"YQ" = (
+/turf/template_noop,
+/area/template_noop)
+"YR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical/surgery)
+"YU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Zs" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/railing{
+	dir = 8;
+	layer = 2.91
+	},
+/obj/effect/turf_decal/box,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/structure/closet/crate/wooden{
+	name = "survival kit"
+	},
+/obj/item/survivalcapsule,
+/obj/item/survivalcapsule,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/cargo)
+"Zv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/spline/fancy/transparent/grey{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ZI" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/bridge)
+"ZQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
+
+(1,1,1) = {"
+CR
+YQ
+YQ
+ru
+ni
+ni
+ni
+ru
+ni
+ni
+ni
+ru
+YQ
+YQ
+CR
+"}
+(2,1,1) = {"
+ru
+ru
+ru
+ru
+NU
+CU
+CU
+ru
+CU
+CU
+qv
+Nu
+ru
+ru
+ru
+"}
+(3,1,1) = {"
+ru
+XJ
+YG
+ru
+Va
+Sx
+Sx
+NW
+Sx
+Sx
+Sx
+bI
+km
+Ul
+ru
+"}
+(4,1,1) = {"
+ru
+dj
+OD
+Ue
+hr
+vL
+FT
+rh
+Xa
+YU
+tD
+im
+Bt
+SH
+ru
+"}
+(5,1,1) = {"
+cu
+yw
+aQ
+ah
+ZQ
+rR
+iY
+nu
+iL
+rF
+Zv
+Ql
+zH
+Qy
+ru
+"}
+(6,1,1) = {"
+ru
+ru
+gj
+tv
+Rv
+Ig
+ii
+ru
+cL
+ru
+so
+lP
+qa
+Od
+nO
+"}
+(7,1,1) = {"
+YQ
+CR
+Dm
+Dm
+Dm
+Dm
+Dm
+Ri
+yF
+cZ
+jj
+jj
+jj
+CR
+YQ
+"}
+(8,1,1) = {"
+YQ
+YQ
+Dm
+LL
+wo
+aE
+Dm
+tk
+jW
+ty
+yn
+aZ
+jj
+YQ
+YQ
+"}
+(9,1,1) = {"
+YQ
+YQ
+Dm
+FL
+Pc
+dd
+Dm
+aL
+df
+ev
+UZ
+xf
+jj
+YQ
+YQ
+"}
+(10,1,1) = {"
+YQ
+YQ
+aU
+OR
+XB
+ob
+nP
+Ky
+yl
+Zs
+cw
+zY
+gP
+YQ
+YQ
+"}
+(11,1,1) = {"
+YQ
+YQ
+Dm
+Em
+nU
+tV
+Dm
+lV
+OP
+dq
+Ld
+iN
+Cr
+re
+YQ
+"}
+(12,1,1) = {"
+YQ
+YQ
+Dm
+qF
+el
+FR
+cy
+rj
+Rr
+Hz
+Oi
+eu
+qf
+YQ
+YQ
+"}
+(13,1,1) = {"
+YQ
+YQ
+Dm
+qA
+qA
+qA
+qA
+tJ
+qS
+Qx
+yH
+zO
+jj
+YQ
+YQ
+"}
+(14,1,1) = {"
+YQ
+YQ
+YQ
+qA
+Jp
+QN
+oN
+Ox
+he
+OW
+Rj
+Pk
+jj
+YQ
+YQ
+"}
+(15,1,1) = {"
+YQ
+YQ
+YQ
+qA
+CP
+Hd
+qA
+nF
+aI
+ot
+ot
+ot
+ot
+YQ
+YQ
+"}
+(16,1,1) = {"
+YQ
+YQ
+YQ
+qA
+qA
+qA
+qA
+vk
+nd
+QM
+hM
+qY
+eX
+YQ
+YQ
+"}
+(17,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+qA
+hT
+qA
+ql
+ot
+YR
+oB
+IP
+eX
+YQ
+YQ
+"}
+(18,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+qA
+Lr
+AM
+yG
+qe
+QJ
+OY
+aI
+ot
+YQ
+YQ
+"}
+(19,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+GV
+bO
+bO
+dA
+bO
+bO
+bO
+GV
+YQ
+YQ
+YQ
+"}
+(20,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+bn
+vN
+aa
+GG
+QO
+bO
+YQ
+YQ
+YQ
+YQ
+"}
+(21,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+bO
+Mb
+Qa
+aT
+DU
+bO
+YQ
+YQ
+YQ
+YQ
+"}
+(22,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+bO
+ZI
+DL
+DB
+fk
+bO
+YQ
+YQ
+YQ
+YQ
+"}
+(23,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+bO
+Xw
+Xc
+Xc
+Xw
+bO
+YQ
+YQ
+YQ
+YQ
+"}
+(24,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+Rz
+JI
+uq
+Rz
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(25,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+Rz
+OM
+FJ
+Rz
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(26,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+Rz
+FH
+FH
+Rz
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(27,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}


### PR DESCRIPTION
Halterio: Kansatsu a la cual se le remplazaron 2 habitaciones para acomodar una armería y un mini medbay.

## PRrrr HISPANICO

<!-- Describe aqui todo los cambios que trae el Pull Request. Trata de usar todas las herramientas a tu disposicion, por ejemplo listas, tablas, imagenes o parrafos documentando todo lo posible. -->

Kansatsu adaptada para las necesidades de **INTEQ**, se le retiraron una sala de juntas y una oficina para acomodar una armería y una _TeenyTiny-med-bay_, para balancear la inclusión de una armería se le eliminaron los "Chameleon Proyector" (item que te hace invisible) y los lentes de visión nocturna.
Ademas se agregaron pósteres propagandísticos de **INTEQ** y una maquina expendedora de cigarrillos.

### **Imagen general:**
![Captura de pantalla (2103)](https://github.com/Helixis/Shiptest/assets/143386316/cde0ebf3-1723-4a92-98ff-10a0237d5c4d)

### **Contenidos Armería:**
![Captura de pantalla (2104)](https://github.com/Helixis/Shiptest/assets/143386316/6b4891db-f145-4cb4-b69d-5f6a7b902bdb)
![Captura de pantalla (2105)](https://github.com/Helixis/Shiptest/assets/143386316/1af5af8c-5a4d-41a5-a2a3-fac5cf895cf7)
![Captura de pantalla (2106)](https://github.com/Helixis/Shiptest/assets/143386316/d998488a-f4ce-4f64-ad9c-f60df8a53e73)
![Captura de pantalla (2107)](https://github.com/Helixis/Shiptest/assets/143386316/d8285031-ae95-4f66-b588-3841527d9784)
![Captura de pantalla (2109)](https://github.com/Helixis/Shiptest/assets/143386316/47ac8dd2-e284-4f97-9f82-38b409c482c0)
![Captura de pantalla (2108)](https://github.com/Helixis/Shiptest/assets/143386316/de08af16-6f8c-4d16-b80c-23a4cd8dd635)

### _TeenyTiny-med-bay:_
![Captura de pantalla (2111)](https://github.com/Helixis/Shiptest/assets/143386316/e7f23d62-2742-4fa7-8837-1a4419e86475)

## Por que es bueno para el juego

<!-- Aqui argumentaras por que crees que los cambios que traes son beneficicios para la codebase. -->

Por que **INTEQ** necesita mas naves pequeñitas y la Kansatsu es _GOD_

